### PR TITLE
HelixVim: rebrand to MacHelix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# AGENTS.md – HelixVim
+# AGENTS.md – MacHelix
 
 ## Purpose
-HelixVim is a native macOS application that provides the Helix editing experience with deep macOS integration. Built entirely in Rust, it combines Helix's modern editing capabilities with a native macOS user interface, offering the best of both worlds without modifying MacVim.
+MacHelix is a native macOS application that provides the Helix editing experience with deep macOS integration. Built entirely in Rust, it combines Helix's modern editing capabilities with a native macOS user interface, offering the best of both worlds without modifying MacVim.
 
 ## Directory Map
 | Path | Description |
@@ -23,7 +23,7 @@ brew bundle  # Brewfile in repo root
 ./scripts/bootstrap.sh  # Set up dependencies and Helix
 
 # Full release build (using just)
-just build  # Builds HelixVim with all optimizations
+just build  # Builds MacHelix with all optimizations
 
 # Development build
 just run  # Builds and runs in development mode
@@ -76,7 +76,7 @@ just fmt  # Applies rustfmt to all files
 
 - **Commit Messages**:
   - Use Conventional Commits format (feat:, fix:, docs:, etc.)
-  - Begin PR titles with "HelixVim:" followed by a concise description
+  - Begin PR titles with "MacHelix:" followed by a concise description
   - Include "Fixes #123" when addressing specific issues
 
 ## Safe-Run Guidelines
@@ -123,7 +123,7 @@ just fmt  # Applies rustfmt to all files
 4. Test the DMG on a clean macOS system
 
 ## Architecture Overview
-HelixVim is built as a native Rust application with the following components:
+MacHelix is built as a native Rust application with the following components:
 
 1. **Helix Core**: Provides the editing engine and text manipulation
 2. **macOS Bridge**: Native Cocoa integration via Rust bindings

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-# Brewfile for HelixVim
+# Brewfile for MacHelix
 
 # Rust toolchain (if not already installed)
 brew "rustup-init"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "helixvim"
+name = "machelix"
 version = "0.1.0"
 edition = "2021"
-authors = ["HelixVim Contributors"]
+authors = ["MacHelix Contributors"]
 description = "Native macOS application for the Helix editor"
-repository = "https://github.com/tycronk20/helixvim"
+repository = "https://github.com/tycronk20/machelix"
 license = "MIT"
 
 [dependencies]
@@ -36,14 +36,14 @@ clap = { version = "4.2", features = ["derive"] }
 cargo-bundle = "0.6.0"
 
 [package.metadata.bundle]
-name = "HelixVim"
-identifier = "com.helixvim.app"
-icon = ["assets/helixvim.icns"]
+name = "MacHelix"
+identifier = "com.machelix.app"
+icon = ["assets/machelix.icns"]
 version = "0.1.0"
-copyright = "Copyright (c) 2025 HelixVim Contributors"
+copyright = "Copyright (c) 2025 MacHelix Contributors"
 category = "public.app-category.developer-tools"
 short_description = "Native macOS application for the Helix editor"
 long_description = """
-HelixVim is a native macOS application that provides the Helix editing experience
+MacHelix is a native macOS application that provides the Helix editing experience
 with deep macOS integration, built entirely in Rust.
 """

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-# HelixVim Justfile
+# MacHelix Justfile
 
 default:
     @just --list
@@ -38,16 +38,16 @@ clippy:
 # Create DMG for distribution
 dmg: bundle
     create-dmg \
-        --volname "HelixVim" \
-        --volicon "assets/helixvim.icns" \
+        --volname "MacHelix" \
+        --volicon "assets/machelix.icns" \
         --window-pos 200 120 \
         --window-size 800 400 \
         --icon-size 100 \
-        --icon "HelixVim.app" 200 190 \
-        --hide-extension "HelixVim.app" \
+        --icon "MacHelix.app" 200 190 \
+        --hide-extension "MacHelix.app" \
         --app-drop-link 600 185 \
-        "HelixVim.dmg" \
-        "target/release/bundle/osx/HelixVim.app"
+        "MacHelix.dmg" \
+        "target/release/bundle/osx/MacHelix.app"
 
 # Watch for changes and run
 watch:

--- a/README.machelix.md
+++ b/README.machelix.md
@@ -1,6 +1,6 @@
-# HelixVim
+# MacHelix
 
-HelixVim is a native macOS application that provides the [Helix](https://helix-editor.com/) editing experience with deep macOS integration. Built entirely in Rust, it combines Helix's modern editing capabilities with a native macOS user interface.
+MacHelix is a native macOS application that provides the [Helix](https://helix-editor.com/) editing experience with deep macOS integration. Built entirely in Rust, it combines Helix's modern editing capabilities with a native macOS user interface.
 
 ## Features
 
@@ -21,15 +21,15 @@ HelixVim is a native macOS application that provides the [Helix](https://helix-e
 ### Homebrew
 
 ```bash
-brew tap tycronk20/helixvim
-brew install helixvim
+brew tap tycronk20/machelix
+brew install machelix
 ```
 
 ### Manual Installation
 
-1. Download the latest release from the [releases page](https://github.com/tycronk20/helixvim/releases)
+1. Download the latest release from the [releases page](https://github.com/tycronk20/machelix/releases)
 2. Open the DMG file
-3. Drag HelixVim.app to your Applications folder
+3. Drag MacHelix.app to your Applications folder
 
 ## Building from Source
 
@@ -42,8 +42,8 @@ brew install helixvim
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/tycronk20/helixvim.git
-   cd helixvim
+   git clone https://github.com/tycronk20/machelix.git
+   cd machelix
    ```
 
 2. Install dependencies:
@@ -56,16 +56,16 @@ brew install helixvim
    ./scripts/bootstrap.sh
    ```
 
-4. Build HelixVim:
+4. Build MacHelix:
    ```bash
    just build
    ```
 
-5. The app bundle will be available at `./HelixVim.app`
+5. The app bundle will be available at `./MacHelix.app`
 
 ## Development Workflow
 
-HelixVim uses [just](https://github.com/casey/just) as a command runner. Common tasks:
+MacHelix uses [just](https://github.com/casey/just) as a command runner. Common tasks:
 
 ```bash
 just run        # Run the application in development mode
@@ -78,11 +78,11 @@ just dmg        # Create distributable DMG
 
 ## Configuration
 
-HelixVim uses Helix's configuration format with additional macOS-specific options. See [CONFIG.md](docs/CONFIG.md) for details.
+MacHelix uses Helix's configuration format with additional macOS-specific options. See [CONFIG.md](docs/CONFIG.md) for details.
 
 ## Architecture
 
-HelixVim is built as a native Rust application with the following components:
+MacHelix is built as a native Rust application with the following components:
 
 - **Helix Core**: Provides the editing engine and text manipulation
 - **macOS Bridge**: Native Cocoa integration via Rust bindings
@@ -95,4 +95,4 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 
-HelixVim is licensed under the same terms as Helix. See [LICENSE](LICENSE) for details.
+MacHelix is licensed under the same terms as Helix. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-Vim - the text editor - for macOS
+MacHelix - the Helix-based text editor for macOS
 
 
-- MacVim homepage: <https://macvim.org>
+- MacHelix homepage: <https://github.com/tycronk20/machelix>
 
-- Download the latest version from [Releases](https://github.com/macvim-dev/macvim/releases/latest)
+- Download the latest version from [Releases](https://github.com/tycronk20/machelix/releases/latest)
 
-- How to [build MacVim from source](https://github.com/macvim-dev/macvim/wiki/Building)
+- How to [build MacHelix from source](https://github.com/tycronk20/machelix/wiki/Building)
 
 - Vim README: [README_vim.md](README_vim.md)
 
-- [![MacVim GitHub CI](https://github.com/macvim-dev/macvim/actions/workflows/ci-macvim.yaml/badge.svg)](https://github.com/macvim-dev/macvim/actions/workflows/ci-macvim.yaml)
+- [![MacHelix GitHub CI](https://github.com/tycronk20/machelix/actions/workflows/ci-machelix.yaml/badge.svg)](https://github.com/tycronk20/machelix/actions/workflows/ci-machelix.yaml)
 
-- Packaged in [![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/macvim.svg)](https://repology.org/metapackage/macvim/versions) [![MacPorts package](https://repology.org/badge/version-for-repo/macports/macvim.svg)](https://repology.org/metapackage/macvim/versions)
+- Packaged via Homebrew and MacPorts (coming soon)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,19 +1,19 @@
-# HelixVim Configuration
+# MacHelix Configuration
 
-HelixVim provides a native macOS experience for the Helix editor. This document describes how to configure HelixVim.
+MacHelix provides a native macOS experience for the Helix editor. This document describes how to configure MacHelix.
 
 ## Configuration Files
 
-HelixVim uses the following configuration files:
+MacHelix uses the following configuration files:
 
 - **Helix Configuration**: `~/.config/helix/config.toml` - Standard Helix configuration
-- **HelixVim Configuration**: `~/.config/helixvim/config.toml` - HelixVim-specific settings
+- **MacHelix Configuration**: `~/.config/machelix/config.toml` - MacHelix-specific settings
 
 ## Helix-Specific Options
 
 All standard Helix configuration options are supported. See the [Helix documentation](https://docs.helix-editor.com/configuration.html) for details.
 
-## HelixVim-Specific Options
+## MacHelix-Specific Options
 
 ### macOS Integration
 
@@ -78,7 +78,7 @@ normal = { ... }
 ```
 
 ```toml
-# ~/.config/helixvim/config.toml - HelixVim specific config
+# ~/.config/machelix/config.toml - MacHelix specific config
 [macos]
 native_menus = true
 native_tabs = true
@@ -105,11 +105,11 @@ toolbar_items = ["new", "open", "save", "undo", "redo"]
 
 ## Command Line Options
 
-HelixVim supports all standard Helix command line options, plus the following:
+MacHelix supports all standard Helix command line options, plus the following:
 
 ```
 USAGE:
-    helixvim [OPTIONS] [FILE]...
+    machelix [OPTIONS] [FILE]...
 
 OPTIONS:
     -h, --help                     Print help information

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Script to bootstrap the HelixVim development environment
+# Script to bootstrap the MacHelix development environment
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 
-echo "==> Setting up HelixVim development environment..."
+echo "==> Setting up MacHelix development environment..."
 
 # Check for Homebrew
 if ! command -v brew &> /dev/null; then
@@ -65,7 +65,7 @@ fi
 if [ ! -f "$REPO_ROOT/Justfile" ]; then
     echo "==> Creating Justfile..."
     cat > "$REPO_ROOT/Justfile" << EOF
-# HelixVim Justfile
+# MacHelix Justfile
 
 default:
     @just --list
@@ -105,16 +105,16 @@ clippy:
 # Create DMG for distribution
 dmg: bundle
     create-dmg \\
-        --volname "HelixVim" \\
-        --volicon "assets/helixvim.icns" \\
+        --volname "MacHelix" \\
+        --volicon "assets/machelix.icns" \\
         --window-pos 200 120 \\
         --window-size 800 400 \\
         --icon-size 100 \\
-        --icon "HelixVim.app" 200 190 \\
-        --hide-extension "HelixVim.app" \\
+        --icon "MacHelix.app" 200 190 \\
+        --hide-extension "MacHelix.app" \\
         --app-drop-link 600 185 \\
-        "HelixVim.dmg" \\
-        "target/release/bundle/osx/HelixVim.app"
+        "MacHelix.dmg" \\
+        "target/release/bundle/osx/MacHelix.app"
 
 # Watch for changes and run
 watch:
@@ -131,12 +131,12 @@ if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
     echo "==> Creating Cargo.toml..."
     cat > "$REPO_ROOT/Cargo.toml" << EOF
 [package]
-name = "helixvim"
+name = "machelix"
 version = "0.1.0"
 edition = "2021"
-authors = ["HelixVim Contributors"]
+authors = ["MacHelix Contributors"]
 description = "Native macOS application for the Helix editor"
-repository = "https://github.com/tycronk20/helixvim"
+repository = "https://github.com/tycronk20/machelix"
 license = "MIT"
 
 [dependencies]
@@ -168,15 +168,15 @@ clap = { version = "4.2", features = ["derive"] }
 cargo-bundle = "0.6.0"
 
 [package.metadata.bundle]
-name = "HelixVim"
-identifier = "com.helixvim.app"
-icon = ["assets/helixvim.icns"]
+name = "MacHelix"
+identifier = "com.machelix.app"
+icon = ["assets/machelix.icns"]
 version = "0.1.0"
-copyright = "Copyright (c) 2025 HelixVim Contributors"
+copyright = "Copyright (c) 2025 MacHelix Contributors"
 category = "public.app-category.developer-tools"
 short_description = "Native macOS application for the Helix editor"
 long_description = """
-HelixVim is a native macOS application that provides the Helix editing experience
+MacHelix is a native macOS application that provides the Helix editing experience
 with deep macOS integration, built entirely in Rust.
 """
 EOF
@@ -187,9 +187,9 @@ if [ ! -f "$REPO_ROOT/src/main.rs" ]; then
     echo "==> Creating main.rs..."
     mkdir -p "$REPO_ROOT/src"
     cat > "$REPO_ROOT/src/main.rs" << EOF
-//! HelixVim - Native macOS application for the Helix editor
+//! MacHelix - Native macOS application for the Helix editor
 //!
-//! This is the main entry point for the HelixVim application.
+//! This is the main entry point for the MacHelix application.
 
 mod app;
 mod editor;
@@ -212,7 +212,7 @@ if [ ! -f "$REPO_ROOT/src/app/mod.rs" ]; then
     echo "==> Creating app module..."
     mkdir -p "$REPO_ROOT/src/app"
     cat > "$REPO_ROOT/src/app/mod.rs" << EOF
-//! Application module for HelixVim
+//! Application module for MacHelix
 //!
 //! This module handles the macOS application lifecycle and window management.
 
@@ -224,7 +224,7 @@ use anyhow::Result;
 
 /// Run the application
 pub fn run() -> Result<()> {
-    println!("HelixVim starting up...");
+    println!("MacHelix starting up...");
     
     // TODO: Initialize window and event loop
     
@@ -234,5 +234,5 @@ EOF
 fi
 
 echo "==> Bootstrap complete!"
-echo "You can now build HelixVim with: just build"
+echo "You can now build MacHelix with: just build"
 echo "Or run it with: just run"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Script to build HelixVim
+# Script to build MacHelix
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 
-echo "==> Building HelixVim..."
+echo "==> Building MacHelix..."
 
 # Check if we need to bootstrap first
 if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then
@@ -32,15 +32,15 @@ if command -v cargo-bundle &> /dev/null; then
     cargo bundle --release
     
     # Create a symlink to the app bundle for convenience
-    if [ -d "$REPO_ROOT/target/release/bundle/osx/HelixVim.app" ]; then
+    if [ -d "$REPO_ROOT/target/release/bundle/osx/MacHelix.app" ]; then
         echo "==> Creating symlink to app bundle..."
-        ln -sf "$REPO_ROOT/target/release/bundle/osx/HelixVim.app" "$REPO_ROOT/HelixVim.app"
-        echo "==> App bundle available at: $REPO_ROOT/HelixVim.app"
+        ln -sf "$REPO_ROOT/target/release/bundle/osx/MacHelix.app" "$REPO_ROOT/MacHelix.app"
+        echo "==> App bundle available at: $REPO_ROOT/MacHelix.app"
     fi
 else
     echo "==> Warning: cargo-bundle not installed, skipping app bundle creation"
     echo "==> Install with: cargo install cargo-bundle"
-    echo "==> Binary available at: $REPO_ROOT/target/release/helixvim"
+    echo "==> Binary available at: $REPO_ROOT/target/release/machelix"
 fi
 
 echo "==> Build complete!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# Script to run tests for HelixVim
+# Script to run tests for MacHelix
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 
-echo "==> Running HelixVim tests..."
+echo "==> Running MacHelix tests..."
 
 # Check if we need to bootstrap first
 if [ ! -f "$REPO_ROOT/Cargo.toml" ]; then

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# UI smoke test for HelixVim
+# UI smoke test for MacHelix
 # This script launches the app headless and checks basic functionality
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -10,10 +10,10 @@ REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 echo "==> Running UI smoke test..."
 
 # Check if app bundle exists
-APP_BUNDLE="$REPO_ROOT/HelixVim.app"
+APP_BUNDLE="$REPO_ROOT/MacHelix.app"
 if [ ! -d "$APP_BUNDLE" ]; then
     # Check if we have a release binary instead
-    BINARY="$REPO_ROOT/target/release/helixvim"
+    BINARY="$REPO_ROOT/target/release/machelix"
     if [ ! -f "$BINARY" ]; then
         echo "Neither app bundle nor binary found"
         echo "Run ./scripts/build.sh first"
@@ -28,7 +28,7 @@ fi
 
 # Create a temporary file for testing
 TEMP_FILE=$(mktemp)
-echo "This is a test file for HelixVim" > "$TEMP_FILE"
+echo "This is a test file for MacHelix" > "$TEMP_FILE"
 
 # Set up a headless environment if needed
 if [ -z "${DISPLAY:-}" ]; then
@@ -44,11 +44,11 @@ else
 fi
 
 # Run the app with the test file
-echo "==> Launching HelixVim with test file..."
+echo "==> Launching MacHelix with test file..."
 if [ "$USE_BINARY" = true ]; then
     $RUNNER "$BINARY" --headless "$TEMP_FILE" &
 else
-    $RUNNER "$APP_BUNDLE/Contents/MacOS/HelixVim" --headless "$TEMP_FILE" &
+    $RUNNER "$APP_BUNDLE/Contents/MacOS/MacHelix" --headless "$TEMP_FILE" &
 fi
 PID=$!
 
@@ -57,7 +57,7 @@ sleep 2
 
 # Check if process is still running
 if ! kill -0 $PID 2>/dev/null; then
-    echo "Error: HelixVim crashed on startup"
+    echo "Error: MacHelix crashed on startup"
     exit 1
 fi
 

--- a/src/MacVim/MMHelixBridge.h
+++ b/src/MacVim/MMHelixBridge.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MMHelixBridge : NSObject
 
-/// Returns the HelixVim version string
+/// Returns the MacHelix version string
 + (NSString *)version;
 
 /// Initialize the Helix editor

--- a/src/MacVim/MMHelixBridge.m
+++ b/src/MacVim/MMHelixBridge.m
@@ -8,10 +8,10 @@
 #import "MMHelixBridge.h"
 
 // Import the C functions from the Rust bridge
-extern const char* helixvim_version(void);
-extern bool helixvim_init(void);
-extern bool helixvim_process_key(const char* key);
-extern void helixvim_free_string(char* s);
+extern const char* machelix_version(void);
+extern bool machelix_init(void);
+extern bool machelix_process_key(const char* key);
+extern void machelix_free_string(char* s);
 
 @implementation MMHelixBridge
 
@@ -25,19 +25,19 @@ extern void helixvim_free_string(char* s);
 }
 
 + (NSString *)version {
-    const char *version = helixvim_version();
+    const char *version = machelix_version();
     NSString *versionString = [NSString stringWithUTF8String:version];
-    helixvim_free_string((char *)version);
+    machelix_free_string((char *)version);
     return versionString;
 }
 
 + (BOOL)initializeHelix {
-    return helixvim_init();
+    return machelix_init();
 }
 
 + (BOOL)processKey:(NSString *)key {
     const char *keyStr = [key UTF8String];
-    return helixvim_process_key(keyStr);
+    return machelix_process_key(keyStr);
 }
 
 @end

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -1,4 +1,4 @@
-//! macOS menu implementation for HelixVim
+//! macOS menu implementation for MacHelix
 //!
 //! This module handles the creation and management of native macOS menus.
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-//! Application module for HelixVim
+//! Application module for MacHelix
 //!
 //! This module handles the macOS application lifecycle and window management.
 
@@ -10,7 +10,7 @@ use anyhow::Result;
 
 /// Run the application
 pub fn run() -> Result<()> {
-    println!("HelixVim starting up...");
+    println!("MacHelix starting up...");
     
     // TODO: Initialize window and event loop
     

--- a/src/app/preferences.rs
+++ b/src/app/preferences.rs
@@ -1,4 +1,4 @@
-//! Preferences window for HelixVim
+//! Preferences window for MacHelix
 //!
 //! This module handles the preferences window and settings UI.
 

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -1,4 +1,4 @@
-//! macOS Services integration for HelixVim
+//! macOS Services integration for MacHelix
 //!
 //! This module handles integration with macOS Services menu.
 

--- a/src/bridge/Cargo.toml
+++ b/src/bridge/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "helixvim_bridge"
+name = "machelix_bridge"
 version = "0.1.0"
 edition = "2021"
-authors = ["HelixVim Contributors"]
+authors = ["MacHelix Contributors"]
 description = "Bridge between Helix and MacVim"
 
 [dependencies]
 libc = "0.2"
 
 [lib]
-name = "helixvim_bridge"
+name = "machelix_bridge"
 crate-type = ["staticlib", "cdylib"]

--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -1,4 +1,4 @@
-//! Clipboard integration for HelixVim
+//! Clipboard integration for MacHelix
 //!
 //! This module provides integration with the macOS clipboard.
 

--- a/src/bridge/cocoa.rs
+++ b/src/bridge/cocoa.rs
@@ -1,4 +1,4 @@
-//! Cocoa integration for HelixVim
+//! Cocoa integration for MacHelix
 //!
 //! This module provides low-level integration with Cocoa APIs.
 

--- a/src/bridge/file_dialog.rs
+++ b/src/bridge/file_dialog.rs
@@ -1,4 +1,4 @@
-//! File dialog integration for HelixVim
+//! File dialog integration for MacHelix
 //!
 //! This module provides integration with macOS file dialogs.
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,4 +1,4 @@
-//! macOS bridge module for HelixVim
+//! macOS bridge module for MacHelix
 //!
 //! This module provides integration with macOS Cocoa APIs.
 

--- a/src/bridge/src/lib.rs
+++ b/src/bridge/src/lib.rs
@@ -1,4 +1,4 @@
-//! HelixVim Bridge
+//! MacHelix Bridge
 //!
 //! This crate provides the bridge between Helix and MacVim's Objective-C code.
 //! It exposes Helix functionality through a C-compatible FFI interface.
@@ -6,24 +6,24 @@
 use std::ffi::{c_char, CStr, CString};
 use std::ptr;
 
-/// FFI interface for HelixVim
+/// FFI interface for MacHelix
 #[no_mangle]
-pub extern "C" fn helixvim_version() -> *const c_char {
-    let version = "HelixVim 0.1.0";
+pub extern "C" fn machelix_version() -> *const c_char {
+    let version = "MacHelix 0.1.0";
     let c_str = CString::new(version).unwrap();
     c_str.into_raw()
 }
 
 /// Initialize Helix editor
 #[no_mangle]
-pub extern "C" fn helixvim_init() -> bool {
+pub extern "C" fn machelix_init() -> bool {
     // TODO: Initialize Helix core
     true
 }
 
 /// Process a keystroke
 #[no_mangle]
-pub extern "C" fn helixvim_process_key(key: *const c_char) -> bool {
+pub extern "C" fn machelix_process_key(key: *const c_char) -> bool {
     if key.is_null() {
         return false;
     }
@@ -38,7 +38,7 @@ pub extern "C" fn helixvim_process_key(key: *const c_char) -> bool {
 
 /// Free a string allocated by this library
 #[no_mangle]
-pub extern "C" fn helixvim_free_string(s: *mut c_char) {
+pub extern "C" fn machelix_free_string(s: *mut c_char) {
     if !s.is_null() {
         unsafe {
             let _ = CString::from_raw(s);
@@ -52,11 +52,11 @@ mod tests {
     
     #[test]
     fn test_version() {
-        let version_ptr = helixvim_version();
+        let version_ptr = machelix_version();
         let version = unsafe { CStr::from_ptr(version_ptr) }.to_str().unwrap();
-        assert!(version.contains("HelixVim"));
+        assert!(version.contains("MacHelix"));
         
         // Clean up
-        helixvim_free_string(version_ptr as *mut c_char);
+        machelix_free_string(version_ptr as *mut c_char);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-//! Configuration module for HelixVim
+//! Configuration module for MacHelix
 //!
 //! This module handles loading and saving configuration.
 
@@ -6,7 +6,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// HelixVim configuration
+/// MacHelix configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// macOS integration options
@@ -257,6 +257,6 @@ impl Config {
     /// Get default configuration path
     pub fn default_path() -> Result<std::path::PathBuf> {
         let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
-        Ok(home.join(".config").join("helixvim").join("config.toml"))
+        Ok(home.join(".config").join("machelix").join("config.toml"))
     }
 }

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -1,4 +1,4 @@
-//! Editor commands for HelixVim
+//! Editor commands for MacHelix
 //!
 //! This module defines commands that can be executed in the editor.
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,4 +1,4 @@
-//! Editor module for HelixVim
+//! Editor module for MacHelix
 //!
 //! This module integrates with Helix's core editing functionality.
 
@@ -9,11 +9,11 @@ use anyhow::Result;
 use helix_core::syntax::Syntax;
 use helix_view::editor::Editor as HelixEditor;
 
-/// HelixVim editor wrapper
+/// MacHelix editor wrapper
 pub struct Editor {
     /// The underlying Helix editor instance
     helix: HelixEditor,
-    // Additional state specific to HelixVim
+    // Additional state specific to MacHelix
 }
 
 impl Editor {

--- a/src/editor/state.rs
+++ b/src/editor/state.rs
@@ -1,4 +1,4 @@
-//! Editor state management for HelixVim
+//! Editor state management for MacHelix
 //!
 //! This module handles the state of the editor, including document management.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-//! HelixVim - Native macOS application for the Helix editor
+//! MacHelix - Native macOS application for the Helix editor
 //!
-//! This is the main entry point for the HelixVim application.
+//! This is the main entry point for the MacHelix application.
 
 mod app;
 mod editor;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,4 @@
-//! UI module for HelixVim
+//! UI module for MacHelix
 //!
 //! This module handles the user interface rendering and interaction.
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1,4 +1,4 @@
-//! GPU-accelerated renderer for HelixVim
+//! GPU-accelerated renderer for MacHelix
 //!
 //! This module handles rendering text and UI elements using wgpu.
 
@@ -6,7 +6,7 @@ use anyhow::Result;
 use wgpu::{Device, Queue, Surface};
 use crate::config::RenderingConfig;
 
-/// Renderer for HelixVim
+/// Renderer for MacHelix
 pub struct Renderer {
     device: Device,
     queue: Queue,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,4 +1,4 @@
-//! Theme handling for HelixVim
+//! Theme handling for MacHelix
 //!
 //! This module handles loading and applying themes.
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1,4 +1,4 @@
-//! Window management for HelixVim
+//! Window management for MacHelix
 //!
 //! This module handles window creation and management.
 
@@ -12,7 +12,7 @@ pub fn create_window(config: &WindowConfig) -> Result<(Window, EventLoop<()>)> {
     let event_loop = EventLoop::new();
     
     let window = WindowBuilder::new()
-        .with_title("HelixVim")
+        .with_title("MacHelix")
         .with_inner_size(winit::dpi::LogicalSize::new(
             config.default_width,
             config.default_height,


### PR DESCRIPTION
## Summary
- rename HelixVim project to **MacHelix**
- update documentation and build scripts
- adjust Rust crate names and configuration paths

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings` *(fails: failed to select a version for the requirement `helix-core`)*
- `cargo test` *(fails: failed to select a version for the requirement `helix-core`)*

------
https://chatgpt.com/codex/tasks/task_e_685024cb548883328dafc096404285a9