### PR TITLE
MacHelix: begin helix integration

### DIFF
--- a/README.machelix.md
+++ b/README.machelix.md
@@ -76,6 +76,11 @@ just bundle     # Create macOS app bundle
 just dmg        # Create distributable DMG
 ```
 
+## Development
+
+The roadmap for replacing Vim with Helix is documented in
+[HELIX_INTEGRATION.md](docs/HELIX_INTEGRATION.md).
+
 ## Configuration
 
 MacHelix uses Helix's configuration format with additional macOS-specific options. See [CONFIG.md](docs/CONFIG.md) for details.

--- a/docs/HELIX_INTEGRATION.md
+++ b/docs/HELIX_INTEGRATION.md
@@ -1,0 +1,14 @@
+# Helix Integration Roadmap
+
+This document outlines the high-level steps for replacing Vim with Helix in MacHelix.
+
+## Steps
+
+1. **Add Helix dependencies** in `Cargo.toml`.
+2. **Create wrapper modules** under `src/editor/` to expose Helix functionality.
+3. **Implement editor state management** in `src/editor/state.rs`.
+4. **Hook up macOS bridge** in `src/app` for native integration.
+5. **Build the UI layer** using `wgpu` and `winit`.
+6. **Run tests** regularly with `just test` and keep code formatted with `just fmt`.
+
+This roadmap will evolve as development progresses.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,8 +11,13 @@ use anyhow::Result;
 /// Run the application
 pub fn run() -> Result<()> {
     println!("MacHelix starting up...");
-    
+    // Initialize macOS bridge
+    crate::bridge::init()?;
+
+    // Create the editor instance
+    let _editor = crate::editor::Editor::new()?;
+
     // TODO: Initialize window and event loop
-    
+
     Ok(())
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! This module integrates with Helix's core editing functionality.
 
-pub mod state;
 pub mod commands;
+pub mod state;
 
 use anyhow::Result;
 use helix_core::syntax::Syntax;
@@ -19,28 +19,30 @@ pub struct Editor {
 impl Editor {
     /// Create a new editor instance
     pub fn new() -> Result<Self> {
-        // TODO: Initialize Helix editor
-        unimplemented!()
+        // Initialize the Helix editor with default configuration
+        let helix = HelixEditor::new();
+
+        Ok(Self { helix })
     }
-    
+
     /// Open a file in the editor
     pub fn open(&mut self, path: &str) -> Result<()> {
         // TODO: Open file in Helix
         Ok(())
     }
-    
+
     /// Save the current file
     pub fn save(&mut self) -> Result<()> {
         // TODO: Save current file
         Ok(())
     }
-    
+
     /// Execute a Helix command
     pub fn execute_command(&mut self, command: &str) -> Result<()> {
         // TODO: Execute command in Helix
         Ok(())
     }
-    
+
     /// Get the current syntax highlighting
     pub fn syntax(&self) -> Option<&Syntax> {
         // TODO: Get current syntax


### PR DESCRIPTION
## Summary
- create `HELIX_INTEGRATION.md` roadmap
- hook up bridge and editor skeleton in `app::run`
- stub out `Editor::new` using Helix editor
- reference the roadmap from the README

## Testing
- `just fmt-check`
- `just clippy` *(fails: failed to select a version for the requirement `helix-core`)*
- `just test` *(fails: failed to select a version for the requirement `helix-core`)*

------
https://chatgpt.com/codex/tasks/task_e_6850281515688332ba01639d15606aaa